### PR TITLE
CertFile based SSL Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /bin/
 /build/
+/.settings/
+/.classpath
+/.project

--- a/README.md
+++ b/README.md
@@ -126,9 +126,13 @@ dependencies {
               <property name="etcd-username">root</property>
               <!-- Optional Password for etcd -->
               <property name="etcd-password">password</property>
-		      <property name="etcd-service-name">hz-discovery-test-cluster</property>
+		       <property name="etcd-service-name">hz-discovery-test-cluster</property>
               <property name="etcd-registrator">org.bitsofinfo.hazelcast.discovery.etcd.LocalDiscoveryNodeRegistrator</property>
-		      <property name="etcd-registrator-config"><![CDATA[
+              <!-- Optional cert/key files for SSL connection to etcd, in case etcd is configured for secure communication -->
+              <property name="etcd-client-cert-location">/path/to/tls.crt</property>
+              <property name="etcd-client-key-location">/path/to/tls.key</property>
+              <property name="etcd-trusted-cert-location">/path/to/trusted.crt</property>
+		       <property name="etcd-registrator-config"><![CDATA[
 					{
 					  "preferPublicAddress":false
 					}

--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ dependencies {
 
 * Launch your hazelcast instances, configured with the Etcd discovery-strategy similar to the below: [see ManualRunner.java](src/test/java/org/bitsofinfo/hazelcast/discovery/etcd/ManualRunner.java) example.
 
+
+## <a id="Secured Communication"></a>Secured Communication
+
+By default, when the HTTPS protocol is defined in order to communicate with ETCD the standard SSLContext is used (usually using 'cacerts' system keystore, if not set otherwise). If you need to define your own
+SSLContext with custom certificates there are three optional parameters for defining input for a custom SSLContext in order to establish secure communication to ETCD.
+
+The optional security properties provide locations of certificates (and keys) for secure communication. You can configure trusted root certificates that are needed for communication with ETCD, when secure communication is enabled for your ETCD instance. You can also provide a client certificate and a private key through 'etcd-client-cert-location' and 'etcd-client-key-location' in case your ETCD has client-authentication activated and requests a client certificate.
+                      
+In case your root certificates and client certificate are chained in one file it is OK to define this file in 'etcd-client-cert-location' and omit the trusted-cert property. The implementation will extract the first certificate as your client certificate and the rest as the trusted root/intermediate certificates. 
+                      
+Certificates should be X509 and provided in a PEM encoded file. Keys can be provided as PKCS#8 or PKCS#1 in a PEM encoded file.
+
+
 ```
 <network>
   <port auto-increment="true">5701</port>

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     compile group: 'com.hazelcast', name: 'hazelcast', version:'3.6+'
     compile group: 'org.mousio', name: 'etcd4j', version:'2.9.0'
     compile group: 'com.google.code.gson', name: 'gson', version:'2.4'
+    compile 'commons-io:commons-io:2.4'
+    compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.60'
+    compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.60'
     
     testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/etcd/EtcdDiscoveryConfiguration.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/etcd/EtcdDiscoveryConfiguration.java
@@ -32,6 +32,15 @@ public class EtcdDiscoveryConfiguration {
 	
 	public static final PropertyDefinition ETCD_DISCOVERY_DELAY_MS = 
 			new SimplePropertyDefinition("etcd-discovery-delay-ms", PropertyTypeConverter.INTEGER);
+
+	public static final PropertyDefinition ETCD_CLIENT_CERT_LOCATION = 
+			new SimplePropertyDefinition("etcd-client-cert-location", true, PropertyTypeConverter.STRING);
+
+	public static final PropertyDefinition ETCD_CLIENT_KEY_LOCATION =
+			new SimplePropertyDefinition("etcd-client-key-location", true, PropertyTypeConverter.STRING);
+
+	public static final PropertyDefinition ETCD_TRUSTED_CERT_LOCATION = 
+			new SimplePropertyDefinition("etcd-trusted-cert-location", true, PropertyTypeConverter.STRING);
 	
 
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/etcd/EtcdDiscoveryStrategy.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/etcd/EtcdDiscoveryStrategy.java
@@ -1,11 +1,36 @@
 package org.bitsofinfo.hazelcast.discovery.etcd;
 
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.StringReader;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import javax.naming.ConfigurationException;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.commons.io.IOUtils;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -17,6 +42,7 @@ import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import mousio.etcd4j.EtcdClient;
 import mousio.etcd4j.responses.EtcdKeysResponse;
 import mousio.etcd4j.responses.EtcdKeysResponse.EtcdNode;
@@ -30,6 +56,13 @@ import mousio.etcd4j.responses.EtcdKeysResponse.EtcdNode;
 public class EtcdDiscoveryStrategy extends AbstractDiscoveryStrategy implements Runnable {
 	
 	public static final String DATE_PATTERN = "yyyy.MM.dd HH:mm:ss.SSS Z";
+	
+	private static final String TEMPORARY_KEY_PASSWORD = "changeit";
+	
+	//custom TLS certs and key
+	static private String trustedCertsLocation; 
+	static private String clientKeyLocation;
+	static private String clientCertLocation;
 
 	// how we connect to etcd
 	private String etcdUrisString;  
@@ -43,6 +76,10 @@ public class EtcdDiscoveryStrategy extends AbstractDiscoveryStrategy implements 
 	// How we register with Etcd
 	private EtcdRegistrator registrator = null;
 	
+	static {
+		Security.addProvider(new BouncyCastleProvider());
+	}
+	
 	
 	/**
 	 * Constructor
@@ -52,14 +89,19 @@ public class EtcdDiscoveryStrategy extends AbstractDiscoveryStrategy implements 
 	 * @param properties
 	 */
 	public EtcdDiscoveryStrategy(DiscoveryNode localDiscoveryNode, ILogger logger, Map<String, Comparable> properties ) {
-
+		
 		super( logger, properties );
 		
 		// get basic properites for the strategy
 		this.etcdUrisString = getOrDefault("etcd-uris",  EtcdDiscoveryConfiguration.ETCD_URIS, "http://localhost:4001");
 		this.etcdUsername = getOrDefault("etcd-username", EtcdDiscoveryConfiguration.ETCD_USERNAME, null);
 		this.etcdPassword = getOrDefault("etcd-password", EtcdDiscoveryConfiguration.ETCD_PASSWORD, null);
-		this.etcdServiceName = getOrDefault("etcd-service-name",  EtcdDiscoveryConfiguration.ETCD_SERVICE_NAME, "");		
+		this.etcdServiceName = getOrDefault("etcd-service-name",  EtcdDiscoveryConfiguration.ETCD_SERVICE_NAME, "");	
+		
+		clientCertLocation = getOrDefault("etcd-client-cert-location",  EtcdDiscoveryConfiguration.ETCD_CLIENT_CERT_LOCATION, "");
+		clientKeyLocation = getOrDefault("etcd-client-key-location",  EtcdDiscoveryConfiguration.ETCD_CLIENT_KEY_LOCATION, "");
+		trustedCertsLocation = getOrDefault("etcd-trusted-cert-location",  EtcdDiscoveryConfiguration.ETCD_TRUSTED_CERT_LOCATION, "");
+		
 		long discoveryDelayMS = getOrDefault("etcd-discovery-delay-ms",  EtcdDiscoveryConfiguration.ETCD_DISCOVERY_DELAY_MS, 30000);
 		
 		/**
@@ -128,9 +170,23 @@ public class EtcdDiscoveryStrategy extends AbstractDiscoveryStrategy implements 
 	
 	protected static EtcdClient getEtcdClient(List<URI> etcdUris, String username, String password) throws Exception {
         // build our clients 
-        
+				
         if (etcdUris.iterator().next().toString().toLowerCase().indexOf("https") != -1) {
-            SslContext sslContext = SslContext.newClientContext();
+            SslContextBuilder builder = SslContextBuilder.forClient();
+            
+            //create custom SSLContext when certs and key are provided, if not there this will return NULL	
+            KeyStore keyStore = readCertsAndCreateKeyStore(clientCertLocation, clientKeyLocation, trustedCertsLocation);
+            	
+            if(keyStore != null) {
+        		KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        		kmf.init(keyStore, TEMPORARY_KEY_PASSWORD.toCharArray());
+        		TrustManagerFactory tmfactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        		tmfactory.init(keyStore);
+            	
+            	builder.keyManager(kmf);
+            	builder.trustManager(tmfactory);
+            }
+            SslContext sslContext = builder.build();
             return new EtcdClient(sslContext, username, password, etcdUris.toArray(new URI[]{}));
         } else {
             return new EtcdClient(username, password, etcdUris.toArray(new URI[]{}));
@@ -190,4 +246,135 @@ public class EtcdDiscoveryStrategy extends AbstractDiscoveryStrategy implements 
 		}
 		
 	}
+
+	private static KeyStore readCertsAndCreateKeyStore(String clientCertLocation, String clientKeyLocation, String trustedCertsLocation) throws ConfigurationException {
+		
+		if(clientCertLocation == null || clientCertLocation.isEmpty() || clientKeyLocation == null || clientKeyLocation.isEmpty()) {
+			return null;
+		}
+		
+		String strTrustedCertsData = null;
+		String strClientKeyData = null;
+		String strClientCertData = null;
+		try (FileInputStream fisTrust = new FileInputStream(trustedCertsLocation)) {
+			strTrustedCertsData = new String(IOUtils.toByteArray(fisTrust));
+		} catch (Exception e) {
+			strTrustedCertsData = null;
+		}
+
+		try (FileInputStream fisKey = new FileInputStream(clientKeyLocation)) {
+			strClientKeyData = new String(IOUtils.toByteArray(fisKey));
+		} catch (Exception e) {
+			strClientKeyData = null;
+		}
+
+		try (FileInputStream fisCert = new FileInputStream(clientCertLocation)) {
+			strClientCertData = new String(IOUtils.toByteArray(fisCert));
+		} catch (Exception e) {
+			strClientCertData = null;
+		}
+
+		if (strClientCertData == null && strClientKeyData == null && strTrustedCertsData == null) {
+			return null; // no SSL
+		}
+    	
+    	return getKeyStore(strTrustedCertsData, strClientKeyData, strClientCertData);
+	}
+	
+	private static KeyStore getKeyStore(String trustedCerts, String clientKey, String clientCert)
+			throws ConfigurationException {
+		try {
+
+			KeyStore keyStore = KeyStore.getInstance("JKS");
+			keyStore.load(null, null);
+
+			PrivateKey privateKey = loadPrivateKey(clientKey);
+
+			if (trustedCerts == null) {
+				List<Certificate> chainedCerts = loadChainedCertificate(clientCert);
+				for (int i = 1; i < chainedCerts.size(); i++) {
+					keyStore.setCertificateEntry("ca-cert-" + i, chainedCerts.get(i));
+				}
+				keyStore.setCertificateEntry("client-cert", chainedCerts.get(0));
+				keyStore.setKeyEntry("client-key", privateKey, TEMPORARY_KEY_PASSWORD.toCharArray(),
+						new Certificate[] { chainedCerts.get(0) });
+			} else {
+				Certificate clientCertificate = loadCertificate(clientCert);
+				List<Certificate> caCertificates = loadChainedCertificate(trustedCerts);
+				for (int i = 0; i < caCertificates.size(); i++) {
+					keyStore.setCertificateEntry("ca-cert-" + i, caCertificates.get(i));
+				}
+				keyStore.setCertificateEntry("client-cert", clientCertificate);
+				keyStore.setKeyEntry("client-key", privateKey, TEMPORARY_KEY_PASSWORD.toCharArray(),
+						new Certificate[] { clientCertificate });
+			}
+			return keyStore;
+		} catch (GeneralSecurityException | IOException e) {
+			ConfigurationException ex = new ConfigurationException("Cannot build keystore");
+			ex.setRootCause(e);
+			throw ex;
+		}
+	}
+
+	
+	private static List<Certificate> loadChainedCertificate(String clientCerts) throws GeneralSecurityException {
+		String beginDelimiter = "-----BEGIN CERTIFICATE-----";
+		String endDelimiter = "-----END CERTIFICATE-----";
+		CertificateFactory certificateFactory = CertificateFactory.getInstance("X509");
+
+		String[] tokens = clientCerts.split(beginDelimiter);
+
+		List<Certificate> result = new ArrayList<>();
+		for (int i = 1; i < tokens.length; i++) {
+			String[] tokens2 = tokens[i].split(endDelimiter);
+			result.add(certificateFactory
+					.generateCertificate(new ByteArrayInputStream(DatatypeConverter.parseBase64Binary(tokens2[0]))));
+
+		}
+		return result;
+	}
+
+	private static Certificate loadCertificate(String certificatePem) throws IOException, GeneralSecurityException {
+		final byte[] content = parseDERFromPEM(certificatePem, "-----BEGIN CERTIFICATE-----",
+				"-----END CERTIFICATE-----");
+		CertificateFactory certificateFactory = CertificateFactory.getInstance("X509");
+		return certificateFactory.generateCertificate(new ByteArrayInputStream(content));
+	}
+
+	private static PrivateKey loadPrivateKey(String privateKeyPem) throws IOException, GeneralSecurityException {
+		// PKCS#8 format
+	    final String PEM_PRIVATE_START = "-----BEGIN PRIVATE KEY-----";
+	    final String PEM_PRIVATE_END = "-----END PRIVATE KEY-----";
+
+		// PKCS#1 format
+		final String PEM_RSA_PRIVATE_START = "-----BEGIN RSA PRIVATE KEY-----";
+		// final String PEM_RSA_PRIVATE_END = "-----END RSA PRIVATE KEY-----";
+
+	    if (privateKeyPem.contains(PEM_PRIVATE_START)) { // PKCS#8 format
+	        privateKeyPem = privateKeyPem.replace(PEM_PRIVATE_START, "").replace(PEM_PRIVATE_END, "");
+	        privateKeyPem = privateKeyPem.replaceAll("\\s", "");
+
+	        byte[] pkcs8EncodedKey = Base64.getDecoder().decode(privateKeyPem);
+
+	        KeyFactory factory = KeyFactory.getInstance("RSA");
+	        return factory.generatePrivate(new PKCS8EncodedKeySpec(pkcs8EncodedKey));
+		} else if (privateKeyPem.contains(PEM_RSA_PRIVATE_START)) { // PKCS#1 format
+			PEMParser pemParser = new PEMParser(new StringReader(privateKeyPem));
+			Object object = pemParser.readObject();
+			pemParser.close();
+			JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+			KeyPair kp = converter.getKeyPair((PEMKeyPair) object);
+
+			return kp.getPrivate();
+		}
+
+		throw new GeneralSecurityException("Not supported format of a private key");
+	}
+
+	private static byte[] parseDERFromPEM(String pem, String beginDelimiter, String endDelimiter) {
+		String[] tokens = pem.split(beginDelimiter);
+		tokens = tokens[1].split(endDelimiter);
+		return DatatypeConverter.parseBase64Binary(tokens[0]);
+	}
+
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/etcd/EtcdDiscoveryStrategyFactory.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/etcd/EtcdDiscoveryStrategyFactory.java
@@ -20,7 +20,10 @@ public class EtcdDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
 						EtcdDiscoveryConfiguration.ETCD_SERVICE_NAME,
 						EtcdDiscoveryConfiguration.ETCD_REGISTRATOR,
 						EtcdDiscoveryConfiguration.ETCD_REGISTRATOR_CONFIG,
-						EtcdDiscoveryConfiguration.ETCD_DISCOVERY_DELAY_MS
+						EtcdDiscoveryConfiguration.ETCD_DISCOVERY_DELAY_MS,
+						EtcdDiscoveryConfiguration.ETCD_CLIENT_CERT_LOCATION,
+						EtcdDiscoveryConfiguration.ETCD_CLIENT_KEY_LOCATION,
+						EtcdDiscoveryConfiguration.ETCD_TRUSTED_CERT_LOCATION
 					});
 
 	public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {

--- a/src/main/resources/hazelcast-etcd-discovery-spi-example.xml
+++ b/src/main/resources/hazelcast-etcd-discovery-spi-example.xml
@@ -64,6 +64,24 @@
                        -->
                       <property name="etcd-discovery-delay-ms">10000</property>
                       
+                      <!-- 
+                      
+                      Optional properties in order to provide certs and keys for secure communication. You can configure trusted root certs
+                      that are needed for communication with etcd, when it is configured to have secure communication enabled.
+                      
+                      You can also provide a client cert and a private key through 'etcd-client-cert-location' and 'etcd-client-key-location' in case
+                      your etcd has client-authentication activated and asks for a client cert.
+                      
+                      In case your root certs and client cert are chained in one file it is ok to define this file in 'etcd-client-cert-location' and
+                      omit the trusted cert property. The implementation will extract the first cert as your client cert and the rest as trusted certs. 
+                      
+                      Certificates should be X509 and provided in PEM encoded file.
+                      Keys can be provided as PKCS#8 or PKCS#1 in a PEM encoded file.
+                      
+                      <property name="etcd-client-cert-location">/path/to/tls.crt</property>
+                      <property name="etcd-client-key-location">/path/to/tls.key</property>
+                      <property name="etcd-trusted-cert-location">/path/to/trusted.crt</property>
+                       -->
                       
                       <!-- 
                             EtcdRegistrator: 


### PR DESCRIPTION
Added possibility to define cert, key and caCert files in order to build SSLContext (optionally)

I used this in an Openshift Env where I referenced the key and certs that were mounted secrets in the container. In that way I didn't need to put the secrets into cacerts, which I guess is the normal way to get these into the default SSLContext.

Maybe this is useful and of interest to others.

Cheers,

Juergen
